### PR TITLE
Fixed image url for CI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[build-img]: https://github.com/LAMPSPUC/StateSpaceModels.jl/workflows/CI/badge.svg?branch=master
+[build-img]: https://github.com/LAMPSPUC/StateSpaceModels.jl/actions/workflows/ci.yml/badge.svg?branch=master
 [build-url]: https://github.com/LAMPSPUC/StateSpaceModels.jl/actions?query=workflow%3ACI
 
 [codecov-img]: https://codecov.io/gh/LAMPSPUC/StateSpaceModels.jl/coverage.svg?branch=master


### PR DESCRIPTION
The build status badge in the README is showing `no status`.

![image](https://github.com/user-attachments/assets/bb834fe9-0e22-4f51-aadc-a8f62a374acc)

I just updated the image URL based on the Github docs here: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge

So it should show this: 

![](https://github.com/LAMPSPUC/StateSpaceModels.jl/actions/workflows/ci.yml/badge.svg?branch=master)

instead of this:

![](https://github.com/LAMPSPUC/StateSpaceModels.jl/workflows/CI/badge.svg?branch=master)